### PR TITLE
Add prepare script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,16 @@
     "deluge",
     "typescript"
   ],
-  "main": "./index.js",
+  "main": "./dist/index.js",
   "typings": "./index.d.ts",
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "scripts": {
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "lint:fix": "eslint --fix src/**/*.ts test/**/*.ts",
-    "prebuild": "rimraf dist",
+    "prepare": "npm run build",
     "build": "tsc -p tsconfig.json",
     "postbuild": "cp package.json dist && cp LICENSE dist && cp README.md dist",
     "build:docs": "typedoc --out docs --target es6 --theme minimal --mode file src && touch docs/.nojekyll",


### PR DESCRIPTION
Add prepare script, add `dist` to `files`, change `main` to `dist/index.js` in package.json.

Allows for doing something like this (npm install from git repo):

```
"dependencies": {
  "@ctrl/deluge": "https://github.com/mitchellhuang/deluge#add-torrent-magnet-package"
}
```

Not sure if changing main will break your publish CI since you're `cd`ing into `dist` and only uploading the files in there.