### PR TITLE
feat: swap tough cookie for cookie-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "dependencies": {
     "@ctrl/magnet-link": "^4.3.0",
     "@ctrl/shared-torrent": "^6.5.1",
+    "cookie-es": "^3.0.1",
     "node-fetch-native": "^1.6.7",
     "ofetch": "^1.5.1",
-    "tough-cookie": "^6.0.1",
     "type-fest": "^5.5.0",
     "ufo": "^1.6.3",
     "uint8array-extras": "^1.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,15 @@ importers:
       '@ctrl/shared-torrent':
         specifier: ^6.5.1
         version: 6.5.1(ofetch@1.5.1)
+      cookie-es:
+        specifier: ^3.0.1
+        version: 3.0.1
       node-fetch-native:
         specifier: ^1.6.7
         version: 1.6.7
       ofetch:
         specifier: ^1.5.1
         version: 1.5.1
-      tough-cookie:
-        specifier: ^6.0.1
-        version: 6.0.1
       type-fest:
         specifier: ^5.5.0
         version: 5.5.0
@@ -695,6 +695,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.0.1:
+    resolution: {integrity: sha512-1HqK6V6Prrm7cHzmjtCzfa370ljqPQoNeWIh5NXYqWwUI2l3DZlzjHHh25ZvJIPfwkiYnCvHykE2MIJkEVD1Rg==}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -845,17 +848,6 @@ packages:
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
-
-  tldts-core@7.0.17:
-    resolution: {integrity: sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==}
-
-  tldts@7.0.17:
-    resolution: {integrity: sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==}
-    hasBin: true
-
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
-    engines: {node: '>=16'}
 
   type-fest@5.5.0:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
@@ -1350,6 +1342,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.0.1: {}
+
   destr@2.0.5: {}
 
   entities@4.5.0: {}
@@ -1549,16 +1543,6 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.0.3: {}
-
-  tldts-core@7.0.17: {}
-
-  tldts@7.0.17:
-    dependencies:
-      tldts-core: 7.0.17
-
-  tough-cookie@6.0.1:
-    dependencies:
-      tldts: 7.0.17
 
   type-fest@5.5.0:
     dependencies:

--- a/src/deluge.ts
+++ b/src/deluge.ts
@@ -726,7 +726,9 @@ export class Deluge implements TorrentClient {
   private _setAuthCookie(setCookie: string | null): void {
     const authSetCookie = setCookie ? splitSetCookieString(setCookie)[0] : undefined;
     const parsed = authSetCookie ? parseSetCookie(authSetCookie) : undefined;
-    const expiresValue = authSetCookie ? /(?:^|;)\s*expires=([^;]+)/i.exec(authSetCookie)?.[1] : undefined;
+    const expiresValue = authSetCookie
+      ? /(?:^|;)\s*expires=([^;]+)/i.exec(authSetCookie)?.[1]
+      : undefined;
     const expires = expiresValue ? new Date(expiresValue) : undefined;
 
     this.state.auth.cookieHeader =

--- a/src/deluge.ts
+++ b/src/deluge.ts
@@ -7,9 +7,9 @@ import type {
   TorrentClientConfig,
   TorrentClientState,
 } from '@ctrl/shared-torrent';
+import { parseSetCookie, splitSetCookieString, stringifyCookie } from 'cookie-es';
 import { FormData } from 'node-fetch-native';
 import { ofetch } from 'ofetch';
-import { Cookie } from 'tough-cookie';
 import type { Jsonify } from 'type-fest';
 import { joinURL } from 'ufo';
 import { base64ToUint8Array, isUint8Array, stringToUint8Array } from 'uint8array-extras';
@@ -38,7 +38,7 @@ import type {
 } from './types.js';
 
 interface DelugeState extends TorrentClientState {
-  auth: { cookie?: Cookie; msgId: number };
+  auth: { cookieHeader?: string; expires?: string; msgId: number };
 }
 
 const defaults: TorrentClientConfig = {
@@ -58,7 +58,8 @@ export class Deluge implements TorrentClient {
       ...state,
       auth: state.auth
         ? {
-            cookie: Cookie.fromJSON(state.auth.cookie),
+            cookieHeader: state.auth.cookieHeader,
+            expires: state.auth.expires ? new Date(state.auth.expires).toISOString() : undefined,
             msgId: state.auth.msgId,
           }
         : { msgId: 0 },
@@ -77,12 +78,7 @@ export class Deluge implements TorrentClient {
     return JSON.parse(
       JSON.stringify({
         ...this.state,
-        auth: this.state.auth
-          ? {
-              cookie: this.state.auth.cookie.toJSON(),
-              msgId: this.state.auth.msgId,
-            }
-          : { msgId: 0 },
+        auth: this.state.auth,
       }),
     );
   }
@@ -157,8 +153,9 @@ export class Deluge implements TorrentClient {
    */
   async checkSession(): Promise<boolean> {
     // cookie is missing or expires in x seconds
-    if (this.state.auth.cookie) {
-      if (this.state.auth.cookie.TTL() < 5000) {
+    if (this.state.auth.cookieHeader) {
+      const expires = this.state.auth.expires ? new Date(this.state.auth.expires) : undefined;
+      if (expires && expires.getTime() - Date.now() < 5000) {
         this.resetSession();
         return false;
       }
@@ -166,7 +163,7 @@ export class Deluge implements TorrentClient {
       return true;
     }
 
-    if (this.state.auth.cookie) {
+    if (this.state.auth.cookieHeader) {
       try {
         const check = await this.request<BooleanStatus>('auth.check_session', undefined, false);
         const body = await check.json();
@@ -193,7 +190,7 @@ export class Deluge implements TorrentClient {
       throw new Error('Auth failed, incorrect password');
     }
 
-    this.state.auth.cookie = Cookie.parse(res.headers.get('set-cookie'));
+    this._setAuthCookie(res.headers.get('set-cookie'));
     return true;
   }
 
@@ -416,7 +413,7 @@ export class Deluge implements TorrentClient {
 
     // update current password to new password
     this.config.password = password;
-    this.state.auth.cookie = Cookie.parse(res.headers.get('set-cookie'));
+    this._setAuthCookie(res.headers.get('set-cookie'));
     return body;
   }
 
@@ -689,7 +686,7 @@ export class Deluge implements TorrentClient {
     }
 
     const headers: any = {
-      Cookie: this.state.auth.cookie?.cookieString?.(),
+      Cookie: this.state.auth.cookieHeader,
     };
     const url = joinURL(this.config.baseUrl, this.config.path);
 
@@ -725,5 +722,37 @@ export class Deluge implements TorrentClient {
     if (!validAuth) {
       throw new Error('Invalid Auth');
     }
+  }
+
+  private _setAuthCookie(setCookie: string | null): void {
+    const authCookie = this._authCookie(setCookie ?? '');
+    this.state.auth.cookieHeader = authCookie?.header;
+    this.state.auth.expires = authCookie?.expires
+      ? new Date(authCookie.expires).toISOString()
+      : undefined;
+  }
+
+  private _authCookie(setCookie: string): { expires?: Date; header: string } | undefined {
+    if (!setCookie) {
+      return undefined;
+    }
+
+    const authSetCookie = splitSetCookieString(setCookie)[0];
+    if (!authSetCookie) {
+      return undefined;
+    }
+
+    const parsed = parseSetCookie(authSetCookie);
+    if (!parsed?.name || parsed.value === undefined) {
+      return undefined;
+    }
+
+    const expiresValue = /(?:^|;)\s*expires=([^;]+)/i.exec(authSetCookie)?.[1];
+    const expires = expiresValue ? new Date(expiresValue) : undefined;
+
+    return {
+      expires: expires && !Number.isNaN(expires.getTime()) ? expires : undefined,
+      header: stringifyCookie({ [parsed.name]: parsed.value }),
+    };
   }
 }

--- a/src/deluge.ts
+++ b/src/deluge.ts
@@ -153,26 +153,25 @@ export class Deluge implements TorrentClient {
    */
   async checkSession(): Promise<boolean> {
     // cookie is missing or expires in x seconds
-    if (this.state.auth.cookieHeader) {
-      const expires = this.state.auth.expires ? new Date(this.state.auth.expires) : undefined;
-      if (expires && expires.getTime() - Date.now() < 5000) {
-        this.resetSession();
-        return false;
-      }
-
-      return true;
+    if (!this.state.auth.cookieHeader) {
+      this.resetSession();
+      return false;
     }
 
-    if (this.state.auth.cookieHeader) {
-      try {
-        const check = await this.request<BooleanStatus>('auth.check_session', undefined, false);
-        const body = await check.json();
-        if (body?.result) {
-          return true;
-        }
-      } catch {
-        // do nothing
+    const expires = this.state.auth.expires ? new Date(this.state.auth.expires) : undefined;
+    if (expires && expires.getTime() - Date.now() < 5000) {
+      this.resetSession();
+      return false;
+    }
+
+    try {
+      const check = await this.request<BooleanStatus>('auth.check_session', undefined, false);
+      const body = check._data;
+      if (body?.result) {
+        return true;
       }
+    } catch {
+      // do nothing
     }
 
     this.resetSession();
@@ -725,34 +724,16 @@ export class Deluge implements TorrentClient {
   }
 
   private _setAuthCookie(setCookie: string | null): void {
-    const authCookie = this._authCookie(setCookie ?? '');
-    this.state.auth.cookieHeader = authCookie?.header;
-    this.state.auth.expires = authCookie?.expires
-      ? new Date(authCookie.expires).toISOString()
-      : undefined;
-  }
-
-  private _authCookie(setCookie: string): { expires?: Date; header: string } | undefined {
-    if (!setCookie) {
-      return undefined;
-    }
-
-    const authSetCookie = splitSetCookieString(setCookie)[0];
-    if (!authSetCookie) {
-      return undefined;
-    }
-
-    const parsed = parseSetCookie(authSetCookie);
-    if (!parsed?.name || parsed.value === undefined) {
-      return undefined;
-    }
-
-    const expiresValue = /(?:^|;)\s*expires=([^;]+)/i.exec(authSetCookie)?.[1];
+    const authSetCookie = setCookie ? splitSetCookieString(setCookie)[0] : undefined;
+    const parsed = authSetCookie ? parseSetCookie(authSetCookie) : undefined;
+    const expiresValue = authSetCookie ? /(?:^|;)\s*expires=([^;]+)/i.exec(authSetCookie)?.[1] : undefined;
     const expires = expiresValue ? new Date(expiresValue) : undefined;
 
-    return {
-      expires: expires && !Number.isNaN(expires.getTime()) ? expires : undefined,
-      header: stringifyCookie({ [parsed.name]: parsed.value }),
-    };
+    this.state.auth.cookieHeader =
+      parsed?.name && parsed.value !== undefined
+        ? stringifyCookie({ [parsed.name]: parsed.value })
+        : undefined;
+    this.state.auth.expires =
+      expires && !Number.isNaN(expires.getTime()) ? expires.toISOString() : undefined;
   }
 }

--- a/test/cookies.spec.ts
+++ b/test/cookies.spec.ts
@@ -6,14 +6,18 @@ const baseUrl = 'http://localhost:8112';
 
 it('should build a request cookie header from the auth set-cookie header', () => {
   const deluge = new Deluge({ baseUrl });
-  (deluge as any)._setAuthCookie('session_id=abc123; expires=Wed, 09 Jun 2027 10:18:14 GMT; HttpOnly');
+  (deluge as any)._setAuthCookie(
+    'session_id=abc123; expires=Wed, 09 Jun 2027 10:18:14 GMT; HttpOnly',
+  );
 
   expect(deluge.state.auth.cookieHeader).toBe('session_id=abc123');
 });
 
 it('should preserve the auth cookie expiration from set-cookie', () => {
   const deluge = new Deluge({ baseUrl });
-  (deluge as any)._setAuthCookie('session_id=abc123; expires=Wed, 09 Jun 2027 10:18:14 GMT; HttpOnly');
+  (deluge as any)._setAuthCookie(
+    'session_id=abc123; expires=Wed, 09 Jun 2027 10:18:14 GMT; HttpOnly',
+  );
 
   expect(deluge.state.auth.expires).toBe('2027-06-09T10:18:14.000Z');
 });

--- a/test/cookies.spec.ts
+++ b/test/cookies.spec.ts
@@ -1,0 +1,31 @@
+import { expect, it } from 'vitest';
+
+import { Deluge } from '../src/index.js';
+
+const baseUrl = 'http://localhost:8112';
+
+it('should build a request cookie header from the auth set-cookie header', () => {
+  const deluge = new Deluge({ baseUrl });
+  (deluge as any)._setAuthCookie('session_id=abc123; expires=Wed, 09 Jun 2027 10:18:14 GMT; HttpOnly');
+
+  expect(deluge.state.auth.cookieHeader).toBe('session_id=abc123');
+});
+
+it('should preserve the auth cookie expiration from set-cookie', () => {
+  const deluge = new Deluge({ baseUrl });
+  (deluge as any)._setAuthCookie('session_id=abc123; expires=Wed, 09 Jun 2027 10:18:14 GMT; HttpOnly');
+
+  expect(deluge.state.auth.expires).toBe('2027-06-09T10:18:14.000Z');
+});
+
+it('should preserve auth cookie state across export and restore', () => {
+  const deluge = new Deluge({ baseUrl });
+  deluge.state.auth = {
+    cookieHeader: 'session_id=abc123',
+    expires: '2027-06-09T10:18:14.000Z',
+    msgId: 7,
+  };
+
+  const restored = Deluge.createFromState(deluge.config, deluge.exportState());
+  expect(restored.state.auth).toEqual(deluge.state.auth);
+});

--- a/test/cookies.spec.ts
+++ b/test/cookies.spec.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest';
+import { expect, it, vi } from 'vitest';
 
 import { Deluge } from '../src/index.js';
 
@@ -32,4 +32,21 @@ it('should preserve auth cookie state across export and restore', () => {
 
   const restored = Deluge.createFromState(deluge.config, deluge.exportState());
   expect(restored.state.auth).toEqual(deluge.state.auth);
+});
+
+it('should validate an existing cookie with auth.check_session', async () => {
+  const deluge = new Deluge({ baseUrl });
+  deluge.state.auth = {
+    cookieHeader: 'session_id=abc123',
+    expires: '2027-06-09T10:18:14.000Z',
+    msgId: 7,
+  };
+
+  const request = vi.spyOn(deluge, 'request').mockResolvedValue({
+    _data: { result: false },
+  } as Awaited<ReturnType<Deluge['request']>>);
+
+  await expect(deluge.checkSession()).resolves.toBe(false);
+  expect(request).toHaveBeenCalledWith('auth.check_session', undefined, false);
+  expect(deluge.state.auth).toEqual({ msgId: 0 });
 });


### PR DESCRIPTION
## Summary
Replace `tough-cookie` with `cookie-es` for Deluge auth/session cookie handling.

- store auth state as plain `cookieHeader` and `expires` strings instead of a `tough-cookie` instance
- keep request cookie generation and expiry tracking in the client
- validate existing sessions with `auth.check_session`
- add focused cookie/state tests

BREAKING CHANGE: exported/restored auth state now uses `auth.cookieHeader` and `auth.expires` instead of `auth.cookie`. Consumers using `exportState()` / `createFromState()` persisted data, or reading `state.auth.cookie` directly, need to update.
